### PR TITLE
Replace smartmatch operators

### DIFF
--- a/tests/glob.rex
+++ b/tests/glob.rex
@@ -9,7 +9,7 @@ task "test", group => "test", sub {
 
   my @c = grep { is_file($_) } glob ("/etc/p*");
 
-  ok("/etc/passwd" ~~ @c, "found /etc/passwd");
+  ok(grep { m:/etc/passwd: } @c, "found /etc/passwd");
 
   done_testing();
 };

--- a/tests/hardware.rex
+++ b/tests/hardware.rex
@@ -13,7 +13,7 @@ task "test", group => "test", sub {
 
   my %hw = Rex::Hardware->get(qw/ Host Kernel Memory Network Swap /);
 
-  ok(@{$hw{Network}->{networkdevices}} ~~ m/(eth0|em0|e1000g0)/, "Found $1");
+  ok(grep { m/(eth0|em0|e1000g0)/ } @{$hw{Network}->{networkdevices}}, "Found $1");
   my $dev = $1;
   ok($hw{Network}->{networkconfiguration}->{"$dev"}->{"ip"} =~ m/^(\d+)\./, "Got IP for $dev");
   ok($hw{Network}->{networkconfiguration}->{"$dev"}->{"netmask"} =~ m/\d+\.|ff/, "Got Netmask for $dev");


### PR DESCRIPTION
Since perl 5.18, this produces a 'Smartmatch is experimental' warning.
